### PR TITLE
Require Node 12+ and fix emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ To get up and running with our NodeJS library quickly, follow [The GUIDE](https:
 
 To contribute to this project, please fork and submit a pull request.
 
+## Supported Environments
+
+The BitPay NodeJS client supports Node.js 12 and higher.
+
 ## License
 
 MIT License

--- a/package-lock.json
+++ b/package-lock.json
@@ -497,12 +497,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/bluebird": {
-      "version": "3.5.36",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
-      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
-      "dev": true
-    },
     "@types/bn.js": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
@@ -571,9 +565,9 @@
       }
     },
     "@types/node": {
-      "version": "11.15.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
-      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g==",
+      "version": "12.20.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.38.tgz",
+      "integrity": "sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ==",
       "dev": true
     },
     "@types/puppeteer": {
@@ -610,13 +604,12 @@
         }
       }
     },
-    "@types/request-promise": {
-      "version": "4.1.48",
-      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.48.tgz",
-      "integrity": "sha512-sLsfxfwP5G3E3U64QXxKwA6ctsxZ7uKyl4I28pMj3JvV+ztWECRns73GL71KMOOJME5u1A5Vs5dkBqyiR1Zcnw==",
+    "@types/request-promise-native": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.18.tgz",
+      "integrity": "sha512-tPnODeISFc/c1LjWyLuZUY+Z0uLB3+IMfNoQyDEi395+j6kTFTTRAqjENjoPJUid4vHRGEozoTrcTrfZM+AcbA==",
       "dev": true,
       "requires": {
-        "@types/bluebird": "*",
         "@types/request": "*"
       }
     },
@@ -630,12 +623,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
       "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
-      "dev": true
-    },
-    "@types/underscore": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.4.tgz",
-      "integrity": "sha512-uO4CD2ELOjw8tasUrAhvnn2W4A0ZECOvMjCivJr4gA9pGgjv+qxKWY9GLTMVEK8ej85BxQOocUyE7hImmSQYcg==",
       "dev": true
     },
     "@types/yargs": {
@@ -963,11 +950,6 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -3800,32 +3782,10 @@
         "uuid": "^3.3.2"
       }
     },
-    "request-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
-      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
-      "requires": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "dependencies": {
-        "request-promise-core": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-          "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-          "requires": {
-            "lodash": "^4.17.19"
-          }
-        }
-      }
-    },
     "request-promise-core": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.15"
       }
@@ -3834,7 +3794,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
       "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
-      "dev": true,
       "requires": {
         "request-promise-core": "1.1.3",
         "stealthy-require": "^1.1.1",
@@ -4634,11 +4593,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
       "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "typings": "dist/index",
   "files": [
     "dist/**/*.js",
-    "dist/**/*.d.ts",
-    "setup/*.js",
-    "setup/*.d.ts"
+    "dist/**/*.d.ts"
   ],
   "scripts": {
     "build": "rimraf dist && tsc -p ./tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -42,18 +42,16 @@
     "bs58": "^4.0.1",
     "elliptic": "^6.5.4",
     "request": "^2.85.0",
-    "request-promise": "^4.2.6",
-    "underscore": "^1.13.2"
+    "request-promise-native": "^1.0.0"
   },
   "devDependencies": {
     "@types/bs58": "^4.0.0",
     "@types/elliptic": "^6.4.14",
     "@types/jest": "^24.0.13",
-    "@types/node": "^11.15.54",
+    "@types/node": "^12",
     "@types/puppeteer": "^1.20.8",
     "@types/request": "^2.48.7",
-    "@types/request-promise": "^4.1.48",
-    "@types/underscore": "^1.11.4",
+    "@types/request-promise-native": "^1.0.18",
     "jest": "^24.9.0",
     "prettier": "^1.17.1",
     "puppeteer": "^1.16.0",

--- a/src/setup/BitPaySetup.ts
+++ b/src/setup/BitPaySetup.ts
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const request = require('request');
-const BitPaySDK = require('../src/index');
+const BitPaySDK = require('../index');
 const readline = require('readline');
 
 let privateKeyPath = __dirname+'/../secure/private_key';

--- a/src/util/RESTcli.ts
+++ b/src/util/RESTcli.ts
@@ -1,7 +1,6 @@
 import {Env, KeyUtils} from "../index";
 import * as qs from "querystring";
-import * as rp from 'request-promise';
-import * as _ from 'underscore';
+import * as rp from 'request-promise-native';
 import * as elliptic from "elliptic";
 import BitPayException from "../Exceptions/BitPayException";
 
@@ -61,7 +60,7 @@ export class RESTcli {
             _options.body = JSON.parse(JSON.stringify(formData));
 
             if (signatureRequired) {
-                _.extend(_options.headers, this.getSignedHeaders(_fullURL, _formData));
+                Object.assign(_options.headers, this.getSignedHeaders(_fullURL, _formData));
             }
 
             return await rp.post(_options).then((resp: any) => resp).then(resp => {
@@ -86,7 +85,7 @@ export class RESTcli {
             _options.qs = parameters;
 
             if (signatureRequired) {
-                _.extend(_options.headers, this.getSignedHeaders(_fullURL, _query));
+                Object.assign(_options.headers, this.getSignedHeaders(_fullURL, _query));
             }
 
             return await rp.get(_options).then((resp: any) => resp).then(resp => {
@@ -105,7 +104,7 @@ export class RESTcli {
             const _fullURL = this._baseUrl + uri;
             const _options = JSON.parse(JSON.stringify(this._commonOptions));
             const _query = '?' + qs.stringify(parameters);
-            _.extend(_options.headers, this.getSignedHeaders(_fullURL, _query));
+            Object.assign(_options.headers, this.getSignedHeaders(_fullURL, _query));
 
             _options.uri = _fullURL;
             _options.qs = parameters;
@@ -126,7 +125,7 @@ export class RESTcli {
             const _fullURL = this._baseUrl + uri;
             const _formData = JSON.stringify(formData);
             const _options = JSON.parse(JSON.stringify(this._commonOptions));
-            _.extend(_options.headers, this.getSignedHeaders(_fullURL, _formData));
+            Object.assign(_options.headers, this.getSignedHeaders(_fullURL, _formData));
 
             _options.uri = _fullURL;
             _options.body = formData;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,14 +3,17 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,
-    "target": "es5",
+    "target": "es2019",
     "outDir": "./dist",
     "sourceMap": true,
     "strictNullChecks": false,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": false,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": false,
+    "forceConsistentCasingInFileNames": true,
   },
   "lib": [
-    "es5",
+    "es2019",
     "node"
   ],
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,7 @@
     "node"
   ],
   "include": [
-    "src/**/*.ts",
-    "setup/*.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
     "src/**/*.spec.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -377,11 +377,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/bluebird@*":
-  version "3.5.33"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.33.tgz#d79c020f283bd50bd76101d7d300313c107325fc"
-  integrity sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ==
-
 "@types/bn.js@*":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
@@ -401,10 +396,10 @@
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
   integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
 
-"@types/elliptic@^6.4.6":
-  version "6.4.12"
-  resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.12.tgz#e8add831f9cc9a88d9d84b3733ff669b68eaa124"
-  integrity sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==
+"@types/elliptic@^6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.14.tgz#7bbaad60567a588c1f08b10893453e6b9b4de48e"
+  integrity sha512-z4OBcDAU0GVwDTuwJzQCiL6188QvZMkvoERgcVjq0/mPM8jCfdwZ3x5zQEVoL9WCAru3aG5wl3Z5Ww5wBWn7ZQ==
   dependencies:
     "@types/bn.js" "*"
 
@@ -440,30 +435,29 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.28.tgz#cade4b64f8438f588951a6b35843ce536853f25b"
   integrity sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==
 
-"@types/node@^11.15.46":
-  version "11.15.53"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.15.53.tgz#24b35ba006338dc60b133f9a637995e1c5a4e069"
-  integrity sha512-X4K0pwvbFZ7+x5wyJUSROj4TJvyXxL0MY4OaxyphfEfgw+0DdYDltyqTX14LiYTIQdY49sDA/MabdtYc973yFg==
+"@types/node@^12":
+  version "12.20.38"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.38.tgz#74801983c0558a7a31a4ead18bce2edded2b0e2f"
+  integrity sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ==
 
-"@types/puppeteer@^1.20.7":
-  version "1.20.7"
-  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-1.20.7.tgz#31fb4274f0c6ec2e90ed8473616243f15a808017"
-  integrity sha512-LCfP/Zf/y4I/hG8ARR8htPYa1wpLpUkysJo9TffmQssVz8c1b9uDNU4benDHSldiz7HVAMek1DCWz7KbqEUg3w==
+"@types/puppeteer@^1.20.8":
+  version "1.20.8"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-1.20.8.tgz#fadbf64f7ac497e9248297beb6ed6a01705c0918"
+  integrity sha512-yJZzz9NeEmTxRGaZzUxUtBIEAoVXTtAx40mG8K0eDPwEeWyuxXKC7Lredxs6uNcgbvMDc8xzYy4v54jbbpoqrg==
   dependencies:
     "@types/node" "*"
 
-"@types/request-promise@^4.1.47":
-  version "4.1.47"
-  resolved "https://registry.yarnpkg.com/@types/request-promise/-/request-promise-4.1.47.tgz#62f58a52476ef6cfe4f38d689cb826959a33a268"
-  integrity sha512-eRSZhAS8SMsrWOM8vbhxFGVZhTbWSJvaRKyufJTdIf4gscUouQvOBlfotPSPHbMR3S7kfkyKbhb1SWPmQdy3KQ==
+"@types/request-promise-native@^1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@types/request-promise-native/-/request-promise-native-1.0.18.tgz#437ee2d0b772e01c9691a983b558084b4b3efc2c"
+  integrity sha512-tPnODeISFc/c1LjWyLuZUY+Z0uLB3+IMfNoQyDEi395+j6kTFTTRAqjENjoPJUid4vHRGEozoTrcTrfZM+AcbA==
   dependencies:
-    "@types/bluebird" "*"
     "@types/request" "*"
 
-"@types/request@*", "@types/request@^2.48.5":
-  version "2.48.5"
-  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.5.tgz#019b8536b402069f6d11bee1b2c03e7f232937a0"
-  integrity sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==
+"@types/request@*", "@types/request@^2.48.7":
+  version "2.48.7"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.7.tgz#a962d11a26e0d71d9a9913d96bb806dc4d4c2f19"
+  integrity sha512-GWP9AZW7foLd4YQxyFZDBepl0lPsWLMEXDZUjQ/c1gqVPDPECrRZyEzuhJdnPWioFCq3Tv0qoGpMD6U+ygd4ZA==
   dependencies:
     "@types/caseless" "*"
     "@types/node" "*"
@@ -479,11 +473,6 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
-
-"@types/underscore@^1.10.24":
-  version "1.10.24"
-  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.10.24.tgz#dede004deed3b3f99c4db0bdb9ee21cae25befdd"
-  integrity sha512-T3NQD8hXNW2sRsSbLNjF/aBo18MyJlbw0lSpQHB/eZZtScPdexN4HSa8cByYwTw9Wy7KuOFr81mlDQcQQaZ79w==
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -727,11 +716,6 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
-
-bluebird@^3.5.0:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bn.js@^4.11.9:
   version "4.11.9"
@@ -2999,21 +2983,11 @@ request-promise-core@1.1.4:
   dependencies:
     lodash "^4.17.19"
 
-request-promise-native@^1.0.5:
+request-promise-native@^1.0.0, request-promise-native@^1.0.5:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.9.tgz#e407120526a5efdc9a39b28a5679bf47b9d9dc28"
   integrity sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
   dependencies:
-    request-promise-core "1.1.4"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
-
-request-promise@^4.2.6:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.6.tgz#7e7e5b9578630e6f598e3813c0f8eb342a27f0a2"
-  integrity sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==
-  dependencies:
-    bluebird "^3.5.0"
     request-promise-core "1.1.4"
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
@@ -3563,15 +3537,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.9:
-  version "3.9.9"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
-  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
-
-underscore@^1.12.0:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
-  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
+typescript@^3.9.10:
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
As discussed in #39 , this PR sets the typescript target to es2019 and removes request-promise (which uses bluebird) in favor of request-promise-native. It also removes the underscore dependency, since the only use of underscore was for `_.extend`, which is easily replaced with es2015+'s `Object.assign`.

After checking out the just-released 2.x version, I noticed the directory structure of the package changed due to the addition of the `setup` directory to tsconfig's include. Typescript was emitting the files to `dist/src/` because `setup/` is a peer of `src/`. As a result, the published version actually doesn't work as-is, because package.json still declares the `main` entrypoint as `dist/index`, but the index file is now in `dist/src/index`. I figured this was probably unintentional, so I moved `setup` under `src` and removed the separate include in tsconfig for it (it looks like the intention is still to include the compiled BitPaySetup.js in the package, correct?). Now the index file is back to `dist/index`. Here's more info on typescript's implicit rootDir and how it interacts with include and outDir: https://www.typescriptlang.org/tsconfig#rootDir

Increasing the required node version is a breaking change so normally semver would require a major version bump. However, since the just-released 2.x has the outfile issue mentioned above and likely won't work for users, you could consider unpublishing the current 2.x and publishing a new one with this change instead. Info on unpublishing: https://docs.npmjs.com/unpublishing-packages-from-the-registry