### PR TITLE
Update Client constructor definition to reflect usage in Guide

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -117,7 +117,7 @@ The pairing code is then entered into the BitPay merchant dashboard for the desi
 ### Create an invoice
 
 ```node
-let invoiceData = new Models.Invoice(50, Currencies.USD);
+let invoiceData = new Models.Invoice(50, Currency.USD);
 
 const result = await client.CreateInvoice(invoiceData);
 
@@ -139,7 +139,7 @@ You can retrieve BitPay's [BBB exchange rates](https://bitpay.com/exchange-rates
 ```node
 let rates = client.GetRates();
 
-let rate = rates.client(Currencies.USD);
+let rate = rates.client(Currency.USD);
 
 rates.update(); // It will refresh the current Rates object
 ```

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -39,21 +39,28 @@ export class Client {
     public _currenciesInfo: [];
     private _keyUtils = new KeyUtils();
 
+    constructor(configFilePath: string);
     constructor(
-        configFilePath: string,
+        configFilePath: null | undefined,
         environment: string,
         privateKey: string,
-        tokens: Tokens,
+        tokens: Tokens
+    );
+    constructor(
+        configFilePath: string | null | undefined,
+        environment?: string,
+        privateKey?: string,
+        tokens?: Tokens,
     ) {
         try {
-            // constructor with config file
-            if(arguments.length > 1) {
+            // constructor with parameters
+            if(configFilePath == null) {
                 this._env = environment;
                 this.BuildConfig(privateKey, tokens);
                 this.initKeys();
                 this.init();
             }
-            // constructor with parameters
+            // constructor with config file
             else {
                 this.BuildConfigFromFile(configFilePath);
                 this.initKeys();


### PR DESCRIPTION
This adds overloads for the `Client` constructor declaration so that it allows passing either just the config file path or the 3 parameters, matching the usage form the Guide. This fixes typescript errors when only passing the json file to the constructor.