### PR TITLE
Create manual workflow to generate releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,107 @@
-on:
-  release:
-    types:
-      - published
+name: Release
 
-name: release
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      overview:
+        description: 'Release overview (will be placed at top of notes)'
+        required: true
 
 jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Push version bump and tag
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          npm version ${{ github.event.inputs.bump }} --no-git-tag-version
+          version=$(jq -r .version package.json)
+          git add package.json package-lock.json
+          git commit -m "Bump version to $version"
+          git tag $version
+          git push origin ${{ github.ref_name }}
+          git push origin $version
+
+      - name: Get merged PR titles and format release notes
+        id: changelog
+        run: |
+          git fetch --tags
+
+          # Get most recent and previous tags
+          tags=($(git tag --sort=-creatordate))
+          new_tag="${tags[0]}"
+          prev_tag="${tags[1]}"
+
+          if [ -z "$prev_tag" ]; then
+            echo "Warning: No previous tag found. Skipping full changelog link."
+            changelog=""
+          else
+            changelog="**Full Changelog**: https://github.com/${{ github.repository }}/compare/$prev_tag...$new_tag"
+          fi
+
+          prs=$(gh pr list --state merged --base "${{ github.ref_name }}" --json title,mergedAt --jq '[.[] | select(.mergedAt != null) | .title]')
+          joined=$(echo "$prs" | jq -r '.[]' | sed 's/^/* /')
+
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          echo "${{ github.event.inputs.overview }}" >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo "## What's Changed" >> $GITHUB_ENV
+          echo "$joined" >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo "$changelog" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release
+        run: |
+          git fetch --tags
+          tag=$(git describe --tags --abbrev=0)
+          gh release create "$tag" --title "$tag" --notes "${{ env.RELEASE_NOTES }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   readme-changelog:
     name: Publish changelog to Readme
+    needs: release
     runs-on: ubuntu-latest
+
     steps:
       - name: Extract release data
         id: release
         run: |
-          echo "title=${{ github.event.release.name }}" >> $GITHUB_OUTPUT
+          echo "title=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          body=$(gh release view ${{ github.ref_name }} --json body --jq .body)
           {
             echo "body<<EOF"
-            echo "${{ github.event.release.body }}"
+            echo "$body"
             echo "EOF"
           } >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Publish changelog to Readme
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}


### PR DESCRIPTION
## Overview

I was thinking about how we could do releases with fewer clicks and still automating the release notes, so I've built a manual workflow.

Here's how it works:
1. Go to Actions
2. Select `Release` from the left-hand panel
3. On the right, click the `Run workflow` button
4. Choose a `Version bump type (_patch_, _minor_, or _major_)`, which will be used in `npm version`
5. Enter a release overview, which is used in the release notes above "What's new" (Readme.com shows the first line in the changelog list view, so it's good to have something other than "What's new" show)

<img width="1264" height="494" alt="Screenshot 2025-07-16 at 8 00 48 PM" src="https://github.com/user-attachments/assets/cc00b63c-feba-4360-a5e2-ab27aa274c7a" />

When you run the workflow, it will:
1. Check out the project
2. Set up Node.js
3. Install the dependencies
4. Set the git username and email
5. Run `npm version` to bump the package.json and package-lock.json, but we use `--no-git-tag-version` because it prefixes with a `v` and we don't want that for this project
7. Uses jq to get the version without `v`
8. Add package.json and package-lock.json
9. Commit
10. Tag
11. Push to the branch that the workflow was run against
12. Push the tag
13. Get a list of PRs
14. Use the GitHub API (with the `gh` command) to get a list of PR titles so we don't need all the "by @dependabot" text
15. Create the GitHub release
16. Push the release notes to the Readme.com changelog

Here's an example from my repo:

<img width="1176" height="655" alt="Screenshot 2025-07-16 at 8 00 09 PM" src="https://github.com/user-attachments/assets/4fd3a644-84ae-4295-9834-75b0248d3fcb" />
