### PR TITLE
Security: Fix untrusted input vulnerability in release workflow - 8.0.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,57 +38,63 @@ jobs:
 
       - name: Push version bump and tag
         id: version
+        env:
+          BUMP: ${{ github.event.inputs.bump }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          npm version ${{ github.event.inputs.bump }} --no-git-tag-version
+          npm version $BUMP --no-git-tag-version
           version=$(jq -r .version package.json)
           echo "version=$version" >> $GITHUB_OUTPUT
           sed -i "s/^export const BitpayPluginInfo = .*$/export const BitpayPluginInfo = 'BitPay_NodeJs_Client_v$version';/" src/Env.ts
           git add package.json package-lock.json src/Env.ts
           git commit -m "Bump version to $version"
           git tag $version
-          git push origin ${{ github.ref_name }}
+          git push origin $REF_NAME
           git push origin $version
 
       - name: Get merged PR titles and format release notes
         id: changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          OVERVIEW: ${{ github.event.inputs.overview }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           git fetch --tags
 
-          # Get most recent and previous tags
           tags=($(git tag --sort=-creatordate))
           new_tag="${tags[0]}"
           prev_tag="${tags[1]}"
 
           if [ -z "$prev_tag" ]; then
-            echo "Warning: No previous tag found. Skipping full changelog link."
             changelog=""
           else
-            changelog="**Full Changelog**: https://github.com/${{ github.repository }}/compare/$prev_tag...$new_tag"
+            changelog="**Full Changelog**: https://github.com/$REPOSITORY/compare/$prev_tag...$new_tag"
           fi
 
-          prs=$(gh pr list --state merged --base "${{ github.ref_name }}" --json title,mergedAt --jq '[.[] | select(.mergedAt != null) | .title]')
+          prs=$(gh pr list --state merged --base "$REF_NAME" --json title,mergedAt --jq '[.[] | select(.mergedAt != null) | .title]')
           joined=$(echo "$prs" | jq -r '.[]' | sed 's/^/* /')
 
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
-          echo "${{ github.event.inputs.overview }}" >> $GITHUB_ENV
+          echo "$OVERVIEW" >> $GITHUB_ENV
           echo "" >> $GITHUB_ENV
           echo "## What's Changed" >> $GITHUB_ENV
           echo "$joined" >> $GITHUB_ENV
           echo "" >> $GITHUB_ENV
           echo "$changelog" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub release
-        run: |
-          gh release create "${{ steps.version.outputs.version }}" \
-            --title "${{ steps.version.outputs.version }}" \
-            --notes "${{ env.RELEASE_NOTES }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
+        run: |
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes "$RELEASE_NOTES"
 
   readme-changelog:
     name: Publish changelog to Readme
@@ -101,9 +107,12 @@ jobs:
 
       - name: Extract release data
         id: release_data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.release.outputs.version }}
         run: |
-          echo "title=${{ needs.release.outputs.version }}" >> $GITHUB_OUTPUT
-          body=$(gh release view ${{ needs.release.outputs.version }} --json body --jq .body)
+          echo "title=$VERSION" >> $GITHUB_OUTPUT
+          body=$(gh release view $VERSION --json body --jq .body)
           body_escaped=$(echo "$body" \
             | sed 's/&/\&#38;/g' \
             | sed 's/</\&#60;/g' \
@@ -115,15 +124,15 @@ jobs:
             echo "$body_escaped"
             echo "EOF"
           } >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish changelog to Readme
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}
+          RELEASE_TITLE: ${{ steps.release_data.outputs.title }}
+          RELEASE_BODY: ${{ steps.release_data.outputs.body }}
         run: |
-          jq -n --arg title "Node.js Unified SDK v${{ steps.release_data.outputs.title }}" \
-                --arg body "${{ steps.release_data.outputs.body }}" \
+          jq -n --arg title "Node.js Unified SDK v$RELEASE_TITLE" \
+                --arg body "$RELEASE_BODY" \
                 '{
                   title: $title,
                   content: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bs58": "6.0.0",
         "elliptic": "6.6.1",
-        "lodash": "4.17.21",
+        "lodash": "4.17.23",
         "zod": "4.3.5"
       },
       "bin": {
@@ -21,7 +21,7 @@
         "@types/bs58": "5.0.0",
         "@types/elliptic": "6.4.18",
         "@types/jest": "30.0.0",
-        "@types/lodash": "4.17.21",
+        "@types/lodash": "4.17.23",
         "@types/node": "25.0.7",
         "@typescript-eslint/eslint-plugin": "8.53.0",
         "@typescript-eslint/parser": "8.53.0",
@@ -1850,9 +1850,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4776,9 +4776,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {

--- a/package.json
+++ b/package.json
@@ -53,14 +53,14 @@
   "dependencies": {
     "bs58": "6.0.0",
     "elliptic": "6.6.1",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "zod": "4.3.5"
   },
   "devDependencies": {
     "@types/bs58": "5.0.0",
     "@types/elliptic": "6.4.18",
     "@types/jest": "30.0.0",
-    "@types/lodash": "4.17.21",
+    "@types/lodash": "4.17.23",
     "@types/node": "25.0.7",
     "@typescript-eslint/eslint-plugin": "8.53.0",
     "@typescript-eslint/parser": "8.53.0",


### PR DESCRIPTION
## Security Fix: Prevent Command Injection in Release Workflow

### Summary
This PR fixes a command injection vulnerability in the GitHub Actions release workflow by moving all untrusted inputs and GitHub context variables to environment variables.

### Problem
The workflow was directly interpolating user inputs and GitHub context variables into shell commands, which could allow command injection attacks. Specifically:

- `${{ github.event.inputs.bump }}` - User-controlled workflow input
- `${{ github.event.inputs.overview }}` - User-controlled workflow input
- `${{ github.ref_name }}` - GitHub context variable
- `${{ github.repository }}` - GitHub context variable
- `${{ steps.version.outputs.version }}` - Step output used in shell commands
- `${{ steps.release_data.outputs.title }}` - Step output used in shell commands
- `${{ steps.release_data.outputs.body }}` - Step output used in shell commands

### Solution
All potentially untrusted values are now passed through environment variables before being used in shell commands. This ensures they are treated as literal strings rather than being evaluated as code.

**Changes made:**
1. **Push version bump and tag** - Moved `BUMP_TYPE` and `REF_NAME` to env vars
2. **Get merged PR titles** - Moved `RELEASE_OVERVIEW`, `REF_NAME`, and `REPOSITORY` to env vars
3. **Create GitHub release** - Moved `VERSION` and `RELEASE_NOTES` to env vars
4. **Extract release data** - Moved `VERSION` to env var
5. **Publish changelog** - Moved `RELEASE_TITLE` and `RELEASE_BODY` to env vars

### Security Impact
This follows the security best practices outlined in the [GitHub Security Lab advisory](https://securitylab.github.com/resources/github-actions-untrusted-input/) and prevents potential command injection through GitHub Actions expressions.

### Testing
- [ ] Workflow syntax is valid
- [ ] No functional changes to workflow behavior
- [ ] All steps continue to work as expected