### PR TITLE
fix: replace crypto.BinaryLike with Buffer in KeyUtils for @types/nod…

### DIFF
--- a/src/util/KeyUtils.ts
+++ b/src/util/KeyUtils.ts
@@ -15,7 +15,7 @@ export class KeyUtils {
   }
 
   public get_sin_from_key(kp: elliptic.ec.KeyPair): string {
-    const pk: crypto.BinaryLike = Buffer.from(kp.getPublic().encodeCompressed());
+    const pk: Buffer = Buffer.from(kp.getPublic().encodeCompressed());
     const version: Buffer = this.get_version_from_compressed_key(pk);
     const checksum: Buffer = this.get_checksum_from_version(version);
     return bs58.encode(Buffer.concat([version, checksum]));
@@ -39,14 +39,14 @@ export class KeyUtils {
     return ecKey.getPublic().encodeCompressed('hex');
   }
 
-  private get_version_from_compressed_key(pk: crypto.BinaryLike): Buffer {
+  private get_version_from_compressed_key(pk: Buffer): Buffer {
     const sh2 = crypto.createHash('sha256').update(pk).digest();
     const rp = crypto.createHash('ripemd160').update(sh2).digest();
 
     return Buffer.concat([Buffer.from('0F', 'hex'), Buffer.from('02', 'hex'), rp]);
   }
 
-  private get_checksum_from_version(version: crypto.BinaryLike): Buffer {
+  private get_checksum_from_version(version: Buffer): Buffer {
     const h1 = crypto.createHash('sha256').update(version).digest();
     const h2 = crypto.createHash('sha256').update(h1).digest();
 


### PR DESCRIPTION
## Problem

Dependabot's `@types/node` 25 → 26 bump (#352, previously #346) fails CI:
all jobs run `npm run build`, and `tsc` errors with:

    src/util/KeyUtils.ts(43,52): error TS2345: Argument of type 'BinaryLike' is not
    assignable to parameter of type 'string | ArrayBufferView<ArrayBufferLike>'.
    src/util/KeyUtils.ts(50,51): error TS2345: (same)

In `@types/node` 26, `crypto.Hash.update()` no longer accepts a plain
`ArrayBuffer`, which the `crypto.BinaryLike` type includes.

## Solution

Type the two private helpers in `KeyUtils` (and one local variable) as `Buffer`
instead of `crypto.BinaryLike` — `Buffer` is what they actually receive from
their only call sites. Type-only change; the emitted JavaScript is identical.

## Verification

- `npm run build` passes with both `@types/node` 25.9.3 (current) and 26.1.0
- `npm run unit`: 55/55 tests pass, identical results before/after
- `format:ci` and `lint` pass
