### PR TITLE
chore(deps): fix npm audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2076,9 +2076,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Problem

The `audit` CI job runs `npm audit --audit-level=high` and is currently failing
on `8.0.x`. Because the vulnerability lives in the base branch dependency tree,
it fails on **every** open pull request, blocking all pending dependabot updates.

## Cause

`js-yaml` 4.3.0 is affected by GHSA-5p4m-2wfm-xmqj (CVE-2026-59870) — quadratic
CPU consumption in `!!omap` resolution — rated **high**.

It is a dev-only transitive dependency, pulled in through `@eslint/eslintrc`,
so the published SDK runtime is not affected.

## Fix

Lockfile-only change generated with `npm audit fix`: bumps the transitive
`js-yaml` from 4.3.0 to 4.3.1. No changes to `package.json` or source code.

## Verification

- `npm audit --audit-level=high` now exits 0
- `npm run lint` passes
- `npm run build` passes
- Unit tests pass (55/55)

The remaining `elliptic` advisory (GHSA-848j-6mx2-7j84) is **low** severity with
no fix available upstream, and does not trip the `--audit-level=high` gate.
